### PR TITLE
Reinstall stack if exists

### DIFF
--- a/build_binaries.sh
+++ b/build_binaries.sh
@@ -17,5 +17,5 @@ fi
 export PATH=$INSTALL_PATH/bin:${PATH}
 UHDM_INSTALL_DIR=$INSTALL_PATH make -C $PWD/yosys-symbiflow-plugins/ install -j$(nproc)
 #sv2v
-wget -qO- https://get.haskellstack.org/ | sh -s - -d $INSTALL_PATH/bin
+wget -qO- https://get.haskellstack.org/ | sh -s - -f -d $INSTALL_PATH/bin
 make -C $PWD/sv2v && cp $PWD/sv2v/bin/sv2v $INSTALL_PATH/bin


### PR DESCRIPTION
build-binaries.sh exited with non-zero exit code if the stack binary already existed. 