### PR TITLE
Fix plugin-only release and CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -381,21 +381,11 @@ jobs:
         ls -lah image
         tar -zcvf $FULL_TARBALL image
         tar -zcvf $PLUGIN_TARBALL image/share/yosys/plugins/uhdm.so install_plugin.sh
-        echo "FULL_TARBALL=$FULL_TARBALL" >> $GITHUB_ENV
-        echo "PLUGIN_TARBALL=$PLUGIN_TARBALL" >> $GITHUB_ENV
     - name: Deploy release
       uses: svenstaro/upload-release-action@v2
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: ${{ env.FULL_TARBALL }}
-        tag: ${{ env.TAG }}
-        overwrite: true
-        file_glob: true
-    - name: Deploy plugin-only release
-      uses: svenstaro/upload-release-action@v2
-      with:
-        repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: ${{ env.PLUGIN_TARBALL }}
+        file: yosys-uhdm-*.tar.gz
         tag: ${{ env.TAG }}
         overwrite: true
         file_glob: true
@@ -406,7 +396,7 @@ jobs:
     name: Test plugin installation
     if: ${{github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')}}
     steps:
-    - name: Install dependencies
+    - name: Install Yosys
       run: sudo apt-get install -y yosys
     - uses: robinraju/release-downloader@v1.3
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -381,11 +381,21 @@ jobs:
         ls -lah image
         tar -zcvf $FULL_TARBALL image
         tar -zcvf $PLUGIN_TARBALL image/share/yosys/plugins/uhdm.so install_plugin.sh
+        echo "FULL_TARBALL=$FULL_TARBALL" >> $GITHUB_ENV
+        echo "PLUGIN_TARBALL=$PLUGIN_TARBALL" >> $GITHUB_ENV
     - name: Deploy release
       uses: svenstaro/upload-release-action@v2
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: yosys-uhdm-*.tar.gz
+        file: ${{ env.FULL_TARBALL }}
+        tag: ${{ env.TAG }}
+        overwrite: true
+        file_glob: true
+    - name: Deploy plugin-only release
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: ${{ env.PLUGIN_TARBALL }}
         tag: ${{ env.TAG }}
         overwrite: true
         file_glob: true
@@ -397,9 +407,7 @@ jobs:
     if: ${{github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')}}
     steps:
     - name: Install dependencies
-      run: |
-        apt-get update -qq
-        apt install -y yosys
+      run: sudo apt-get install -y yosys
     - uses: robinraju/release-downloader@v1.3
       with:
         repository: "antmicro/yosys-uhdm-plugin-integration"


### PR DESCRIPTION
1. Full release and plugin release are uploaded in separate steps (as the action apparently only supports one file to be uploaded).
2. Now Yosys is installed with sudo on GH runner.

Signed-off-by: Krzysztof Bieganski <kbieganski@antmicro.com>