### PR TITLE
Explicite set tarball as release download format

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -403,6 +403,7 @@ jobs:
         repository: "antmicro/yosys-uhdm-plugin-integration"
         fileName: "yosys-uhdm-plugin-*.tar.gz"
         latest: true
+        tarBall: true
     - name: Extract UHDM plugin and install it
       run: |
         tar -xzf yosys-uhdm-plugin-*.tar.gz


### PR DESCRIPTION
This tries to fix Test plugin install  CI by explicite set tarball as release download format. Currently both zip and tarball is set to false: https://github.com/antmicro/yosys-uhdm-plugin-integration/runs/5094062008?check_suite_focus=true#step:3:6
Signed-off-by: Kamil Rakoczy <krakoczy@antmicro.com>