### PR TITLE
Add resource usage graphs as CI artifacts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,6 +60,12 @@ jobs:
         name: binaries
         path: |
           binaries.tar
+
+    - name: Upload load graphs
+      uses: actions/upload-artifact@v2
+      with:
+        name: plots
+        path: |
           **/plot_*.svg
 
   generate-matrix-yosys:
@@ -155,6 +161,13 @@ jobs:
         TEST_CASE: ${{ matrix.TEST_CASE_YOSYS }}
         TARGET: uhdm/yosys/test-ast
 
+    - name: Upload load graphs
+      uses: actions/upload-artifact@v2
+      with:
+        name: plots
+        path: |
+          **/plot_*.svg
+
   tests-vcddiff:
     runs-on: [self-hosted, Linux, X64]
     container: ubuntu:latest
@@ -204,6 +217,13 @@ jobs:
         name: ${{ matrix.TEST_CASE_VCDDIFF }}.sv
         path: UHDM-integration-tests/build/yosys.sv
 
+    - name: Upload load graphs
+      uses: actions/upload-artifact@v2
+      with:
+        name: plots
+        path: |
+          **/plot_*.svg
+
   ibex_synth:
     runs-on: [self-hosted, Linux, X64]
     container: ubuntu:latest
@@ -248,6 +268,13 @@ jobs:
       with:
         name: lowrisc_ibex_top_artya7_surelog_0.1.edif
         path: UHDM-integration-tests/build/lowrisc_ibex_top_artya7_surelog_0.1/synth-yosys/lowrisc_ibex_top_artya7_surelog_0.1.edif
+
+    - name: Upload load graphs
+      uses: actions/upload-artifact@v2
+      with:
+        name: plots
+        path: |
+          **/plot_*.svg
 
   opentitan_synth:
     runs-on: [self-hosted, Linux, X64]
@@ -294,6 +321,13 @@ jobs:
         name: top_earlgrey_nexysvideo.edif
         path: UHDM-integration-tests/build/top_earlgrey_nexysvideo.edif
 
+    - name: Upload load graphs
+      uses: actions/upload-artifact@v2
+      with:
+        name: plots
+        path: |
+          **/plot_*.svg
+
   swerv_synth:
     runs-on: [self-hosted, Linux, X64]
     container: ubuntu:latest
@@ -338,6 +372,13 @@ jobs:
       with:
         name: chipsalliance.org_cores_SweRV_EH1_1.8.edif
         path: UHDM-integration-tests/build/chipsalliance.org_cores_SweRV_EH1_1.8/synth-vivado/chipsalliance.org_cores_SweRV_EH1_1.8.edif
+
+    - name: Upload load graphs
+      uses: actions/upload-artifact@v2
+      with:
+        name: plots
+        path: |
+          **/plot_*.svg
 
   release:
     needs: [ build-binaries, tests-yosys, ibex_synth, opentitan_synth]
@@ -429,3 +470,10 @@ jobs:
       with:
         name: top_artya7.bit
         path: ./UHDM-integration-tests/build/lowrisc_ibex_top_artya7_surelog_0.1/synth-symbiflow/top_artya7.bit
+
+    - name: Upload load graphs
+      uses: actions/upload-artifact@v2
+      with:
+        name: plots
+        path: |
+          **/plot_*.svg


### PR DESCRIPTION
This PR adds an artifact containing system resource usage graphs that are generated automatically by runners.

Plots that were already present were moved to a separate step to keep them in one archive.