### PR TITLE
Build opentitan bitstream

### DIFF
--- a/.github/scripts/bisect.sh
+++ b/.github/scripts/bisect.sh
@@ -1,0 +1,11 @@
+set -ex
+OT_DIR=`pwd`
+ROOT_DIR=$OT_DIR/../../..
+
+echo "::group::BISECT"
+
+rm -rf $OT_DIR/.gitpatch
+cd ${ROOT_DIR}
+$ROOT_DIR/UHDM-integration-tests/.github/ci.sh || (ec=$?; cd ${OT_DIR}; git checkout .; exit $ec;)
+
+echo "::endgroup::"

--- a/.github/scripts/common.sh
+++ b/.github/scripts/common.sh
@@ -1,0 +1,10 @@
+function enable_vivado() {
+    echo
+    echo "======================================="
+    echo "Creating Vivado Symbolic Link"
+    echo "---------------------------------------"
+	ln -s /mnt/aux/Xilinx /opt/Xilinx
+	ls /opt/Xilinx/Vivado
+	source /opt/Xilinx/Vivado/$1/settings64.sh
+	vivado -version
+}

--- a/.github/scripts/compare_ast.py
+++ b/.github/scripts/compare_ast.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+import re
+import os
+import sys
+import subprocess
+
+def parse_file(file_path):
+    module_dict = {}
+    current_module_name = ""
+    with open(file_path, 'r') as f:
+        lines = f.readlines()
+        for line in lines:
+            if "Generating" in line or "Dumping" in line or "END OF AST DUMP" in line:
+                continue
+            stripped_line = line.strip()
+            if stripped_line.startswith("AST_MODULE"):
+                line = line.replace("basic_prep", "")
+                start = line.find("str='")
+                line = line.rstrip()
+                module_name = line[start+5:]
+                #if module_name.endswith('\''):
+                #    module_name = module_name[:-1]
+                if "\\$paramod" in module_name:
+                    current_module_name = module_name.replace("\\$paramod", "")
+                else:
+                    current_module_name = module_name
+                begin = current_module_name.find("\\")
+                if begin != -1:
+                    end = current_module_name.find("\\", begin + 1, len(current_module_name))
+                    current_module_name = current_module_name[begin:end]
+                if current_module_name == "":
+                    current_module_name = module_name
+                current_module_name = current_module_name.replace(' ', '')
+                current_module_name = current_module_name.replace('\\', '')
+
+
+            if current_module_name != "":
+                if "\n" not in line:
+                    line = line + "\n"
+                if current_module_name in module_dict:
+                    module_dict[current_module_name].append(line)
+                else:
+                    module_dict[current_module_name] = [line]
+
+            line = f.readline()
+
+    return module_dict
+
+first = parse_file(sys.argv[1])
+second = parse_file(sys.argv[2])
+
+os.makedirs("compare", exist_ok=True)
+
+first_sorted = {}
+second_sorted = {}
+
+for key in sorted(first.keys()):
+    start_skip = False
+    skip_line = 0
+    current_line = 1
+    for line in first[key]:
+        if key in first_sorted:
+            first_sorted[key].append(line)
+        else:
+            first_sorted[key] = [line]
+        current_line += 1
+
+    with open(f'compare/first_{key}.ast', 'w') as f:
+        f.writelines(first[key])
+
+for key in sorted(second.keys()):
+    start_skip = False
+    skip_line = 0
+    current_line = 1
+    for line in second[key]:
+        if key in second_sorted:
+            second_sorted[key].append(line)
+        else:
+            second_sorted[key] = [line]
+        current_line += 1
+
+    with open(f'compare/second_{key}.ast', 'w') as f:
+        f.writelines(second[key])
+
+for key in first.keys():
+    if key in second.keys():
+        subprocess.run(["diff", f"compare/first_{key}.ast", f"compare/second_{key}.ast"])
+        second.pop(key)
+    else:
+        print(f"Additional module in first file: {key}")
+
+for key in second.keys():
+    print(f"Additional module in second file: {key}")
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
 
   build-binaries:
     runs-on: [self-hosted, Linux, X64]
-    container: ubuntu:latest
+    container: ubuntu:bionic
     env:
       CC: gcc-9
       CXX: g++-9
@@ -22,7 +22,10 @@ jobs:
     - name: Install dependencies
       run: |
         apt-get update -qq
-        apt install -y g++-9 build-essential cmake tclsh ant default-jre swig google-perftools libgoogle-perftools-dev python3 python3-dev python3-pip uuid uuid-dev tcl-dev flex libfl-dev git pkg-config libreadline-dev bison libffi-dev wget ccache
+        apt install -y software-properties-common
+        add-apt-repository ppa:ubuntu-toolchain-r/test
+        apt-get update -qq
+        apt install -y gcc-9 g++-9 build-essential cmake tclsh ant default-jre swig google-perftools libgoogle-perftools-dev python3 python3-dev python3-pip uuid uuid-dev tcl-dev flex libfl-dev git pkg-config libreadline-dev bison libffi-dev wget ccache
         update-alternatives --install /usr/bin/python python /usr/bin/python3 1
         update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
         pip install orderedmultidict
@@ -47,6 +50,8 @@ jobs:
 
     - name: Build binaries
       run: |
+        # ubuntu bionic have too old cmake, install one from pip
+        pip install cmake
         # Github dropped support for unauthorized git: https://github.blog/2021-09-01-improving-git-protocol-security-github/
         # Make sure we always use https:// instead of git://
         git config --global url.https://github.com/.insteadOf git://github.com/
@@ -74,7 +79,7 @@ jobs:
 
   generate-matrix-yosys:
     runs-on: [self-hosted, Linux, X64]
-    container: ubuntu:latest
+    container: ubuntu:bionic
     outputs:
       matrix: ${{ steps.generate-matrix-yosys.outputs.matrix }}
     steps:
@@ -99,7 +104,7 @@ jobs:
 
   generate-matrix-vcddiff:
     runs-on: [self-hosted, Linux, X64]
-    container: ubuntu:latest
+    container: ubuntu:bionic
     outputs:
       matrix: ${{ steps.generate-matrix-vcddiff.outputs.matrix }}
     steps:
@@ -125,7 +130,7 @@ jobs:
 
   tests-yosys:
     runs-on: [self-hosted, Linux, X64]
-    container: ubuntu:latest
+    container: ubuntu:bionic
     needs: [build-binaries, generate-matrix-yosys]
     strategy:
       matrix:
@@ -143,7 +148,10 @@ jobs:
     - name: Install dependencies
       run: |
         apt-get update -qq
-        apt install -y g++-9 build-essential cmake tclsh ant default-jre swig google-perftools libgoogle-perftools-dev python3 python3-dev uuid uuid-dev tcl-dev flex libfl-dev
+        apt install -y software-properties-common
+        add-apt-repository ppa:ubuntu-toolchain-r/test
+        apt-get update -qq
+        apt install -y gcc-9 g++-9 build-essential cmake tclsh ant default-jre swig google-perftools libgoogle-perftools-dev python3 python3-dev uuid uuid-dev tcl-dev flex libfl-dev
 
     - uses: actions/checkout@v2
       with:
@@ -174,7 +182,7 @@ jobs:
 
   tests-vcddiff:
     runs-on: [self-hosted, Linux, X64]
-    container: ubuntu:latest
+    container: ubuntu:bionic
     needs: [build-binaries, generate-matrix-vcddiff]
     strategy:
       matrix:
@@ -192,7 +200,10 @@ jobs:
     - name: Install dependencies
       run: |
         apt-get update -qq
-        apt install -y g++-9 build-essential cmake tclsh ant default-jre swig google-perftools libgoogle-perftools-dev python3 python3-dev uuid uuid-dev tcl-dev flex libfl-dev
+        apt install -y software-properties-common
+        add-apt-repository ppa:ubuntu-toolchain-r/test
+        apt-get update -qq
+        apt install -y gcc-9 g++-9 build-essential cmake tclsh ant default-jre swig google-perftools libgoogle-perftools-dev python3 python3-dev uuid uuid-dev tcl-dev flex libfl-dev
 
     - uses: actions/checkout@v2
       with:
@@ -230,19 +241,23 @@ jobs:
 
   ibex_synth:
     runs-on: [self-hosted, Linux, X64]
-    container: ubuntu:latest
+    container: ubuntu:bionic
     needs: build-binaries
     env:
       CC: gcc-9
       CXX: g++-9
       DEBIAN_FRONTEND: noninteractive
+      GHA_EXTERNAL_DISK: "tools"
 
     steps:
 
     - name: Install dependencies
       run: |
         apt-get update -qq
-        apt install -y g++-9 build-essential cmake tclsh ant default-jre swig google-perftools libgoogle-perftools-dev python3 python3-dev uuid uuid-dev tcl-dev flex libfl-dev git python3-pip
+        apt install -y software-properties-common
+        add-apt-repository ppa:ubuntu-toolchain-r/test
+        apt-get update -qq
+        apt install -y gcc-9 g++-9 build-essential cmake tclsh ant default-jre swig google-perftools libgoogle-perftools-dev python3 python3-dev uuid uuid-dev tcl-dev flex libfl-dev git python3-pip
         update-alternatives --install /usr/bin/python python /usr/bin/python3 1
         update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
 
@@ -262,16 +277,18 @@ jobs:
 
     - name: Build & Test
       run: |
+        source .github/scripts/common.sh
+        enable_vivado 2017.2
         pip install virtualenv
         ./UHDM-integration-tests/.github/ci.sh
       env:
-        TARGET: uhdm/yosys/synth-ibex
+        TARGET: uhdm/yosys/synth-ibex-build
         TEST_CASE: tests/ibex
 
     - uses: actions/upload-artifact@v2
       with:
-        name: lowrisc_ibex_top_artya7_surelog_0.1.edif
-        path: UHDM-integration-tests/build/lowrisc_ibex_top_artya7_surelog_0.1/synth-yosys/lowrisc_ibex_top_artya7_surelog_0.1.edif
+        name: lowrisc_ibex_top_artya7_surelog_0.1.bit
+        path: UHDM-integration-tests/build/lowrisc_ibex_top_artya7_surelog_0.1/synth-vivado/lowrisc_ibex_top_artya7_surelog_0.1.bit
 
     - name: Upload load graphs
       uses: actions/upload-artifact@v2
@@ -282,19 +299,24 @@ jobs:
 
   opentitan_synth:
     runs-on: [self-hosted, Linux, X64]
-    container: ubuntu:latest
+    # vivado is linked with libraries used in this version of ubuntu
+    container: ubuntu:bionic
     needs: build-binaries
     env:
       CC: gcc-9
       CXX: g++-9
       DEBIAN_FRONTEND: noninteractive
+      GHA_EXTERNAL_DISK: "tools"
 
     steps:
 
     - name: Install dependencies
       run: |
         apt-get update -qq
-        apt install -y g++-9 build-essential cmake tclsh ant default-jre swig google-perftools libgoogle-perftools-dev python3 python3-dev uuid uuid-dev tcl-dev flex libfl-dev ninja-build srecord libftdi1-dev git python3-pip
+        apt install -y software-properties-common
+        add-apt-repository ppa:ubuntu-toolchain-r/test
+        apt-get update -qq
+        apt install -y gcc-9 g++-9 build-essential cmake tclsh ant default-jre swig google-perftools libgoogle-perftools-dev python3 python3-dev uuid uuid-dev tcl-dev flex libfl-dev ninja-build srecord libftdi1-dev git python3-pip
         update-alternatives --install /usr/bin/python python /usr/bin/python3 1
         update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
 
@@ -314,16 +336,118 @@ jobs:
 
     - name: Build & Test
       run: |
+        source .github/scripts/common.sh
+        enable_vivado 2017.2
         pip install virtualenv
         ./UHDM-integration-tests/.github/ci.sh
       env:
-        TARGET: uhdm/yosys/synth-opentitan
+        TARGET: uhdm/yosys/synth-opentitan-build
+        TEST_CASE: tests/opentitan
+
+    - name: Generate AST
+      run: |
+        FILE_NAME=UHDM-integration-tests/build/lowrisc_systems_top_earlgrey_nexysvideo_0.1/synth-vivado/yosys.log
+        start=$(grep -n "AST_MODULE" $FILE_NAME |cut -f1 -d:|head -n 1)
+        end=$(grep -n "AST_" $FILE_NAME |cut -f1 -d:|tail -n 1)
+
+        sed -n $start,"$end"p $FILE_NAME > yosys.ast
+
+    - name: Upload AST
+      uses: actions/upload-artifact@v2
+      if: ${{github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')}}
+      with:
+        name: opentitan-yosys.ast
+        path: yosys.ast
+
+          # Uncomment when first job on master will pass
+          #    - name: Download binaries
+          #      if: ${{ github.event_name == 'pull_request' }}
+          #      uses: actions/download-artifact@v2
+          #      with:
+          #        name: opentitan-yosys.ast
+
+          #    - name: Compare AST
+          #      if: ${{ github.event_name == 'pull_request' }}
+          #      run: |
+          #        mkdir compare
+          #        ./github/scripts/compare_ast.py opentitan-yosys.ast yosys.ast
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: lowrisc_systems_top_earlgrey_nexysvideo_0.1.bit
+        path: UHDM-integration-tests/build/lowrisc_systems_top_earlgrey_nexysvideo_0.1/synth-vivado/lowrisc_systems_top_earlgrey_nexysvideo_0.1.bit
+
+    - name: Upload load graphs
+      uses: actions/upload-artifact@v2
+      with:
+        name: plots
+        path: |
+          **/plot_*.svg
+
+  opentitan_bisect:
+    runs-on: [self-hosted, Linux, X64]
+    # vivado is linked with libraries used in this version of ubuntu
+    container: ubuntu:bionic
+    needs: build-binaries
+    env:
+      CC: gcc-9
+      CXX: g++-9
+      DEBIAN_FRONTEND: noninteractive
+      GHA_EXTERNAL_DISK: "tools"
+
+    steps:
+
+    - name: Install dependencies
+      run: |
+        apt-get update -qq
+        apt install -y software-properties-common
+        add-apt-repository ppa:ubuntu-toolchain-r/test
+        apt-get update -qq
+        apt install -y gcc-9 g++-9 build-essential cmake tclsh ant default-jre swig google-perftools libgoogle-perftools-dev python3 python3-dev uuid uuid-dev tcl-dev flex libfl-dev ninja-build srecord libftdi1-dev git python3-pip
+        update-alternatives --install /usr/bin/python python /usr/bin/python3 1
+        update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
+
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+        fetch-depth: 1
+
+    - name: Download binaries
+      uses: actions/download-artifact@v2
+      with:
+        name: binaries
+
+    # See https://github.com/actions/upload-artifact/issues/38
+    - name: Extract
+      run: tar -xf binaries.tar
+
+    - name: Build & Test
+      run: |
+        source .github/scripts/common.sh
+        enable_vivado 2017.2
+        pip install virtualenv
+        cd uhdm-tests/opentitan/opentitan
+        pwd
+        ls -la
+        git status
+        git remote -v
+        GOOD_REF=$(git rev-list --max-count=1 HEAD)
+        git pull --unshallow
+        git pull origin master
+        BAD_REF=$(git rev-list --max-count=1 HEAD)
+        COUNT_REF=$(git log ${GOOD_REF}..${BAD_REF} --oneline | wc -l)
+        git bisect start HEAD ${GOOD_REF} --
+        echo "GOOD_REF: ${GOOD_REF}, BAD_REF: ${BAD_REF}, commits: ${COUNT_REF}"
+        git bisect run ../../../.github/scripts/bisect.sh
+        git bisect reset
+      env:
+        TARGET: uhdm/yosys/synth-opentitan-build
         TEST_CASE: tests/opentitan
 
     - uses: actions/upload-artifact@v2
       with:
-        name: lowrisc_systems_top_earlgrey_nexysvideo_0.1.edif
-        path: UHDM-integration-tests/build/lowrisc_systems_top_earlgrey_nexysvideo_0.1/synth-yosys/lowrisc_systems_top_earlgrey_nexysvideo_0.1.edif
+        name: lowrisc_systems_top_earlgrey_nexysvideo_0.1.bit
+        path: UHDM-integration-tests/build/lowrisc_systems_top_earlgrey_nexysvideo_0.1/synth-vivado/lowrisc_systems_top_earlgrey_nexysvideo_0.1.bit
 
     - name: Upload load graphs
       uses: actions/upload-artifact@v2
@@ -334,7 +458,7 @@ jobs:
 
   swerv_synth:
     runs-on: [self-hosted, Linux, X64]
-    container: ubuntu:latest
+    container: ubuntu:bionic
     needs: build-binaries
     env:
       CC: gcc-9
@@ -346,7 +470,10 @@ jobs:
     - name: Install dependencies
       run: |
         apt-get update -qq
-        apt install -y g++-9 build-essential cmake tclsh ant default-jre swig google-perftools libgoogle-perftools-dev python3 python3-dev uuid uuid-dev tcl-dev flex libfl-dev ninja-build srecord libftdi1-dev git python3-pip
+        apt install -y software-properties-common
+        add-apt-repository ppa:ubuntu-toolchain-r/test
+        apt-get update -qq
+        apt install -y gcc-9 g++-9 build-essential cmake tclsh ant default-jre swig google-perftools libgoogle-perftools-dev python3 python3-dev uuid uuid-dev tcl-dev flex libfl-dev ninja-build srecord libftdi1-dev git python3-pip
         update-alternatives --install /usr/bin/python python /usr/bin/python3 1
         update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
 
@@ -385,7 +512,7 @@ jobs:
           **/plot_*.svg
 
   release:
-    needs: [ build-binaries, tests-yosys, ibex_synth, opentitan_synth]
+    needs: [ build-binaries, tests-yosys, ibex_synth, opentitan_synth, tests-vcddiff, ibex_synth_symbiflow, swerv_synth]
     runs-on: ubuntu-20.04
     name: Release
     if: ${{github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')}}
@@ -457,7 +584,7 @@ jobs:
 
   ibex_synth_symbiflow:
     runs-on: [self-hosted, Linux, X64]
-    container: ubuntu:latest
+    container: ubuntu:bionic
     needs: build-binaries
     env:
       CC: gcc-9
@@ -469,7 +596,10 @@ jobs:
     - name: Install dependencies
       run: |
         apt-get update -qq
-        apt install -y g++-9 build-essential cmake tclsh ant default-jre swig google-perftools libgoogle-perftools-dev python3 python3-dev uuid uuid-dev tcl-dev flex libfl-dev git python3-pip wget
+        apt install -y software-properties-common
+        add-apt-repository ppa:ubuntu-toolchain-r/test
+        apt-get update -qq
+        apt install -y gcc-9 g++-9 build-essential cmake tclsh ant default-jre swig google-perftools libgoogle-perftools-dev python3 python3-dev uuid uuid-dev tcl-dev flex libfl-dev git python3-pip wget
         update-alternatives --install /usr/bin/python python /usr/bin/python3 1
         update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
     - uses: actions/checkout@v2

--- a/uhdm-tests/opentitan/0001-Add-opentitan-patch-for-uhdm.patch
+++ b/uhdm-tests/opentitan/0001-Add-opentitan-patch-for-uhdm.patch
@@ -1,8 +1,8 @@
 diff --git a/hw/ip/otbn/rtl/otbn_decoder.sv b/hw/ip/otbn/rtl/otbn_decoder.sv
-index 9956cd19c..142bf53eb 100644
+index 8cd4814d7..90fdd2b17 100644
 --- a/hw/ip/otbn/rtl/otbn_decoder.sv
 +++ b/hw/ip/otbn/rtl/otbn_decoder.sv
-@@ -127,7 +127,7 @@ module otbn_decoder
+@@ -123,7 +123,7 @@ module otbn_decoder
    // Decoder //
    /////////////
  
@@ -106,34 +106,8 @@ index f601d503e..70dd6d438 100755
  
          if not is_last:
              s += " "
-diff --git a/hw/ip/rstmgr/rtl/rstmgr_pkg.sv b/hw/ip/rstmgr/rtl/rstmgr_pkg.sv
-index 9d4ea8b6a..f8478dbe0 100644
---- a/hw/ip/rstmgr/rtl/rstmgr_pkg.sv
-+++ b/hw/ip/rstmgr/rtl/rstmgr_pkg.sv
-@@ -38,6 +38,7 @@ package rstmgr_pkg;
-     logic rst_por_n;
-     logic rst_por_io_n;
-     logic rst_por_io_div2_n;
-+    logic rst_por_io_div4_n;
-     logic rst_por_usb_n;
-     logic rst_lc_n;
-     logic rst_sys_n;
-@@ -53,6 +54,13 @@ package rstmgr_pkg;
-     logic ndmreset_req;
-   } rstmgr_cpu_t;
- 
-+  // exported resets
-+  typedef struct packed {
-+    logic rst_ast_usbdev_sys_io_n;
-+    logic rst_ast_usbdev_usb_n;
-+    logic rst_ast_sensor_ctrl_sys_io_n;
-+  } rstmgr_ast_out_t;
-+
-   // default value for rstmgr_ast_rsp_t (for dangling ports)
-   parameter rstmgr_cpu_t RSTMGR_CPU_DEFAULT = '{
-     rst_cpu_n: 1'b1,
 diff --git a/hw/top_earlgrey/top_earlgrey_nexysvideo.core b/hw/top_earlgrey/top_earlgrey_nexysvideo.core
-index 8d6cf89b6..276bfceea 100644
+index 8d6cf89b6..6480e08ba 100644
 --- a/hw/top_earlgrey/top_earlgrey_nexysvideo.core
 +++ b/hw/top_earlgrey/top_earlgrey_nexysvideo.core
 @@ -56,7 +56,7 @@ targets:
@@ -151,12 +125,12 @@ index 8d6cf89b6..276bfceea 100644
          part: "xc7a200tsbg484-1" # Nexys Video
 +        synth: "yosys"
 +        yosys_synth_options: ['-flatten', '-iopad', '-noclkbuf', '-family xc7', "frontend=surelog"]
-+        yosys_read_options: []
++        yosys_read_options: ['-dump_ast1', '-dump_ast2', '-no_dump_ptr']
 +        surelog_options: ['-DSYNTHESIS']
 +      yosys:
 +        arch: "xilinx"
-+        yosys_synth_options: ['-iopad', '-noclkbuf', '-family xc7', "frontend=surelog"]
-+        yosys_read_options: []
++        yosys_synth_options: ['-flatten', '-iopad', '-noclkbuf', '-family xc7', "frontend=surelog"]
++        yosys_read_options: ['-dump_ast1', '-dump_ast2', '-no_dump_ptr']
 +        surelog_options: ['-DSYNTHESIS']
  
    lint:


### PR DESCRIPTION
This PR enables building ibex and opentitan bitstream using vivado and uploads bitstream to artifacts.

It also reverts opentitan to last know working version (with working bitstream on HW) and adds automatic bisect of opentitan (finding newest next working version) in CI.
Signed-off-by: Kamil Rakoczy <krakoczy@antmicro.com>