### PR TITLE
Fix plugin-only release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -581,7 +581,9 @@ jobs:
     - name: Install it
       run: |
         ./install_plugin.sh
-    - name: Run Yosys and load UHDM plugin
+    - name: Run Yosys and load SystemVerilog plugin
+      run: yosys -p "plugin -i systemverilog"
+    - name: Run Yosys and load (deprecated) UHDM plugin
       run: yosys -p "plugin -i uhdm"
 
   ibex_synth_symbiflow:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -550,7 +550,7 @@ jobs:
         echo "TAG=$TAG" >> $GITHUB_ENV
         ls -lah image
         tar -zcvf $FULL_TARBALL image
-        tar -zcvf $PLUGIN_TARBALL image/share/yosys/plugins/uhdm.so install_plugin.sh
+        tar -zcvf $PLUGIN_TARBALL image/share/yosys/plugins/uhdm.so image/share/yosys/plugins/systemverilog.so install_plugin.sh
     - name: Deploy release
       uses: svenstaro/upload-release-action@v2
       with:


### PR DESCRIPTION
Add renamed plugin (`systemverilog.so`) to release. Install script expects both it and `uhdm.so` for backward compatibility.