### PR TITLE
Fix cmake build with external surelog, fix cmake install command

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,7 +128,7 @@ set(WITH_STATIC_CRT
     CACHE BOOL "Use Static CRT")
 
 if(SYNLIG_USE_HOST_SURELOG)
-  find_package(SURELOG REQUIRED)
+  find_package(Surelog REQUIRED)
   find_package(UHDM REQUIRED)
   find_package(CapnProto)
   set(UHDM_LIBRARY uhdm::uhdm)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -281,8 +281,10 @@ if(VENDORED_YOSYS)
   add_dependencies(capnp yosys)
 endif()
 
-add_dependencies(synlig surelog)
-add_dependencies(synlig uhdm)
+if(NOT SYNLIG_USE_HOST_SURELOG)
+  add_dependencies(synlig surelog)
+  add_dependencies(synlig uhdm)
+endif()
 target_link_libraries(synlig PUBLIC ${UHDM_LIBRARY})
 target_link_libraries(synlig PUBLIC ${SURELOG_LIBRARY})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ endif(NOT CMAKE_BUILD_TYPE)
 
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/modules" ${CMAKE_MODULE_PATH})
 
-set(INSTALL_DIR ${PROJECT_SOURCE_DIR}/install)
+set(INSTALL_DIR ${PROJECT_SOURCE_DIR}/out/current)
 
 option(
   WITH_LIBCXX
@@ -318,21 +318,5 @@ target_include_directories(synlig PUBLIC $<BUILD_INTERFACE:${JSON_INCLUDE_DIR}>
 target_include_directories(synlig PUBLIC $<BUILD_INTERFACE:${YOSYS_INCLUDE_DIR}>
                                          $<INSTALL_INTERFACE:include>)
 
-include(GNUInstallDirs)
-
-# Generate cmake config files for reuse by downstream packages
-include(CMakePackageConfigHelpers)
-
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/SynligConfig.cmake
-              ${CMAKE_CURRENT_BINARY_DIR}/SynligConfigVersion.cmake
-        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/Synlig)
-
-# install the configuration file
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/Synlig.pc DESTINATION lib/pkgconfig)
-
-add_custom_target(
-  synlig_link_target ALL
-  COMMAND
-    ${CMAKE_COMMAND} -E create_symlink
-    ${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json
-    ${PROJECT_SOURCE_DIR}/compile_commands.json)
+# Install library using normal shell script
+install(CODE "execute_process(COMMAND ${CMAKE_SOURCE_DIR}/install_plugin.sh)")

--- a/install_plugin.sh
+++ b/install_plugin.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 set -e
 


### PR DESCRIPTION
When building against external surelog/yosys:

```
cmake -DSYNLIG_USE_HOST_SURELOG=ON -DSYNLIG_USE_HOST_CAPNP=ON -DSYNLIG_USE_HOST_GTEST=ON -DSYNLIG_USE_HOST_YOSYS=OFF -DYOSYS_CONFIG=yosys-config -DYOSYS_PATH=/opt/homebrew/Cellar/yosys/0.35/share/yosys/include -DSYNLIG_WITH_TCMALLOC=OFF -DSYNLIG_WITH_ZLIB=ON -B build_shared -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_STANDARD=17 -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_CXX_COMPILER_LAUNCHER=/opt/homebrew/bin/ccache -DBUILD_SHARED_LIBS=ON .
```

Before:

```
CMake Error at CMakeLists.txt:284 (add_dependencies):
  The dependency target "surelog" of target "synlig" does not exist.


CMake Error at CMakeLists.txt:285 (add_dependencies):
  The dependency target "uhdm" of target "synlig" does not exist.
```


After: Works.


Similarly for the `cmake --install` command, before:

```
CMake Error at build_shared/cmake_install.cmake:41 (file):
  file INSTALL cannot find
  "synlig/build_shared/SynligConfig.cmake":
  No such file or directory.

```

After: Works.

xref: https://github.com/dau-dev/tools/releases/tag/v0.0.2